### PR TITLE
call fsRenameFile when uploading a file so that it creates missing pa…

### DIFF
--- a/cmd/fs-v1-helpers.go
+++ b/cmd/fs-v1-helpers.go
@@ -298,7 +298,7 @@ func fsOpenFile(ctx context.Context, readPath string, offset int64) (io.ReadClos
 }
 
 // Creates a file and copies data from incoming reader.
-func fsCreateFile(ctx context.Context, filePath string, reader io.Reader, fallocSize int64) (int64, error) {
+func fsCreateFile(ctx context.Context, filePath string, reader io.Reader) (int64, error) {
 	if filePath == "" || reader == nil {
 		logger.LogIf(ctx, errInvalidArgument)
 		return 0, errInvalidArgument

--- a/cmd/fs-v1-multipart.go
+++ b/cmd/fs-v1-multipart.go
@@ -320,7 +320,7 @@ func (fs *FSObjects) PutObjectPart(ctx context.Context, bucket, object, uploadID
 	}
 
 	tmpPartPath := pathJoin(fs.fsPath, minioMetaTmpBucket, fs.fsUUID, uploadID+"."+mustGetUUID()+"."+strconv.Itoa(partID))
-	bytesWritten, err := fsCreateFile(ctx, tmpPartPath, data, data.Size())
+	bytesWritten, err := fsCreateFile(ctx, tmpPartPath, data)
 
 	// Delete temporary part in case of failure. If
 	// PutObjectPart succeeds then there would be nothing to


### PR DESCRIPTION
Deleted writeId function in fs-v1.go, using the minio way instead:

Writing the id to a tmp file and then renaming the path to the file calling the function fsRenameFile that creates missing parents folder

error was from trying to create a file in a non existing folder.