### PR TITLE
fix bug and improve recovery mechanism

### DIFF
--- a/cmd/fs-v1-multipart.go
+++ b/cmd/fs-v1-multipart.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -795,7 +796,8 @@ func (fs *FSObjects) CompleteMultipartUpload(ctx context.Context, bucket string,
 
 	p := pathJoin(fs.fsPath, bucket, object)
 	configId := getConfigId(ctx, fs.fsPath, bucket)
-	err = gateway.Shard(ctx, p, configId, object, fsOpenFile)
+	fullPath := path.Join(bucket, object)
+	err = gateway.Shard(ctx, p, configId, fullPath, fsOpenFile)
 
 	if err != nil {
 		return oi, toObjectErr(err, bucket, object)

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -1125,7 +1125,8 @@ func (fs *FSObjects) putObject(ctx context.Context, bucket string, object string
 		p := pathJoin(fs.fsPath, bucket, object)
 
 		configId := getConfigId(ctx, fs.fsPath, bucket)
-		bId, err := gateway.Put(data, object, configId)
+		objPath := path.Join(bucket, object)
+		bId, err := gateway.Put(data, objPath, configId)
 
 		fsMeta.Meta["etag"] = r.MD5CurrentHexString()
 

--- a/cmd/mantle/gateway/sds.go
+++ b/cmd/mantle/gateway/sds.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/minio/minio/cmd/mantle/network"
@@ -63,12 +62,9 @@ func Shard(ctx context.Context, p string, configId string, object string, fsOpen
 
 func Put(f io.Reader, fn string, configId string) (string, error) {
 	client := &http.Client{}
-	val := map[string]io.Reader{
-		"file":        f,
-		"DisplayName": strings.NewReader(fn),
-	}
+	nr := network.NamedReader{&f, fn}
 
-	putResp, err := network.UploadFormData(client, urlJoin("files"), val, setMantleHeaders(configId))
+	putResp, err := network.UploadFormData(client, urlJoin("files"), nr, setMantleHeaders(configId))
 	if err != nil {
 		//TODO:handle
 		fmt.Println(err.Error())

--- a/cmd/mantle/network/models.go
+++ b/cmd/mantle/network/models.go
@@ -1,6 +1,13 @@
 package network
 
+import "io"
+
 type PutFileResp struct {
 	Id string
 	//other fields are available.
+}
+
+type NamedReader struct {
+	R    *io.Reader
+	Name string
 }

--- a/cmd/mantle/network/network.go
+++ b/cmd/mantle/network/network.go
@@ -12,8 +12,33 @@ import (
 	"strings"
 )
 
-func UploadFormData(client *http.Client, url string, nr NamedReader, headers map[string]string) (PutFileResp, error) {
+func writeFormToUpload(temp *os.File, nr NamedReader) (*multipart.Writer, error) {
+	w := multipart.NewWriter(temp)
+	r := *nr.R
+	if x, ok := r.(io.Closer); ok {
+		defer x.Close()
+	}
 
+	fw, err := w.CreateFormFile("file", nr.Name)
+	if _, err = io.Copy(fw, r); err != nil {
+		return nil, err
+	}
+
+	fw, err = w.CreateFormField("DisplayName")
+	if _, err = io.Copy(fw, strings.NewReader(nr.Name)); err != nil {
+		return nil, err
+	}
+
+	err = w.Close()
+	if err != nil {
+		fmt.Printf("Could not close writer:\n%+v\n", err)
+		return nil, err
+	}
+
+	return w, nil
+}
+
+func UploadFormData(client *http.Client, url string, nr NamedReader, headers map[string]string) (PutFileResp, error) {
 	temp, err := os.CreateTemp("", "sds-upload")
 	if err != nil {
 		fmt.Println(err.Error())
@@ -29,32 +54,19 @@ func UploadFormData(client *http.Client, url string, nr NamedReader, headers map
 
 	}()
 
-	w := multipart.NewWriter(temp)
-	r := *nr.R
-	if x, ok := r.(io.Closer); ok {
-		defer x.Close()
-	}
-
-	fw, err := w.CreateFormFile("file", nr.Name)
-	if _, err = io.Copy(fw, r); err != nil {
+	w, err := writeFormToUpload(temp, nr)
+	if err != nil {
+		fmt.Printf("Could not create form to upload:\n%+v\n", err)
 		return PutFileResp{}, err
 	}
 
-	fw, err = w.CreateFormField("DisplayName")
-	if _, err = io.Copy(fw, strings.NewReader(nr.Name)); err != nil {
-		return PutFileResp{}, err
-	}
-
-	w.Close()
 	temp.Seek(0, 0)
-
 	req, err := http.NewRequest(http.MethodPost, url, temp)
 	if err != nil {
 		return PutFileResp{}, err
 	}
 
 	setHeaders(headers, req)
-
 	req.Header.Set("Content-type", w.FormDataContentType())
 
 	res, err := client.Do(req)


### PR DESCRIPTION
### **User description**
improve recovery mechanism: now we store full path eg: folder1/file1 was stored as file1. now map saves -> folder1/file1

bugfix: displayName was not set properly.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Store full file paths (bucket/object) instead of just object names

- Fix displayName field not being set properly in uploads

- Refactor UploadFormData to use NamedReader struct

- Improve form data handling with dedicated writeFormToUpload function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["File operations<br/>fs-v1.go, fs-v1-multipart.go"] -->|"Pass full path<br/>bucket/object"| B["Gateway functions<br/>Put, Shard"]
  B -->|"Use NamedReader"| C["UploadFormData<br/>network.go"]
  C -->|"Set DisplayName<br/>correctly"| D["Form submission<br/>with full path"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fs-v1-multipart.go</strong><dd><code>Pass full path to gateway Shard function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/fs-v1-multipart.go

<ul><li>Added <code>path</code> import for path operations<br> <li> Modified <code>CompleteMultipartUpload</code> to pass full path (bucket/object) to <br><code>gateway.Shard</code> instead of just object name</ul>


</details>


  </td>
  <td><a href="https://github.com/mantle-labs/minio/pull/41/files#diff-fde7d30cd27fcedcf992a5133b117a05f97e6b8e5587e067324835e1c2b4fcc2">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fs-v1.go</strong><dd><code>Pass full path to gateway Put function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/fs-v1.go

<ul><li>Added <code>path</code> import for path operations<br> <li> Modified <code>putObject</code> to construct and pass full path (bucket/object) to <br><code>gateway.Put</code> instead of just object name</ul>


</details>


  </td>
  <td><a href="https://github.com/mantle-labs/minio/pull/41/files#diff-dfb4f3b1a092d47bd851897924d628abddb4d308daca2084686183f0e1016e6a">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sds.go</strong><dd><code>Refactor Put function to use NamedReader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/mantle/gateway/sds.go

<ul><li>Removed unused <code>strings</code> import<br> <li> Refactored <code>Put</code> function to accept <code>NamedReader</code> struct instead of map of <br>readers<br> <li> Simplified form data construction by delegating to <code>UploadFormData</code></ul>


</details>


  </td>
  <td><a href="https://github.com/mantle-labs/minio/pull/41/files#diff-8d07ce62bb1a2bdae07984cf09bc2f374d704e39aa6cb915c569db5ff8d9d2d5">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>network.go</strong><dd><code>Refactor UploadFormData with NamedReader support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/mantle/network/network.go

<ul><li>Added <code>strings</code> import<br> <li> Extracted form writing logic into new <code>writeFormToUpload</code> helper <br>function<br> <li> Modified <code>UploadFormData</code> signature to accept <code>NamedReader</code> instead of map <br>of readers<br> <li> Properly set DisplayName field using the full path from NamedReader<br> <li> Improved error handling and code organization</ul>


</details>


  </td>
  <td><a href="https://github.com/mantle-labs/minio/pull/41/files#diff-65a15f39a7c272a3700a65c747e6d3da94871f05fc87e86e84bc4470ba37207e">+31/-27</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>models.go</strong><dd><code>Add NamedReader struct for file uploads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/mantle/network/models.go

<ul><li>Added <code>io</code> import<br> <li> Added new <code>NamedReader</code> struct with <code>R</code> (io.Reader pointer) and <code>Name</code> <br>(string) fields</ul>


</details>


  </td>
  <td><a href="https://github.com/mantle-labs/minio/pull/41/files#diff-62a1f25cac1f55992bc8f9c4101eaa15f6411b66cd4221fa6423ee0841c6a1b5">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

